### PR TITLE
Some ergonomic improvements for error reporting

### DIFF
--- a/src/Tintin/Capabilities/Logging.hs
+++ b/src/Tintin/Capabilities/Logging.hs
@@ -68,5 +68,5 @@ mute :: Capability
 mute = Capability
   { _log = return . const ()
   , _debug = return . const ()
-  , _err = return . const ()
+  , _err   = putTextLn . ("[ERROR] - " <>)
   }

--- a/src/Tintin/Domain/HtmlFile.hs
+++ b/src/Tintin/Domain/HtmlFile.hs
@@ -10,6 +10,10 @@ require Data.Text
 
 newtype CompilationError = CompilationError Text deriving Show
 
+showCompilationError :: CompilationError
+                     -> Text
+showCompilationError (CompilationError e) = "CompilationError\n" <> e
+
 data HtmlFile = HtmlFile
   { filename :: Text
   , title    :: Text

--- a/src/Tintin/Errors.hs
+++ b/src/Tintin/Errors.hs
@@ -1,9 +1,11 @@
 module Tintin.Errors
   ( Errors
   , showAndDie
+  , textDie
   )
 where
 
+import qualified Data.Text as T
 import Tintin.Core
 require Tintin.Capabilities.Logging
 
@@ -17,5 +19,14 @@ showAndDie :: ( Has Logging.Capability eff
 showAndDie errors = do
     errors
      |> mapM_ (Logging.err . show)
-    error "Errors found. Exiting."
+    die "Errors found. Exiting."
+
+textDie :: ( Has Logging.Capability eff
+           )
+        => [T.Text]
+        -> Effectful eff ()
+textDie errors = do
+    errors
+     |> mapM_ Logging.err
+    die "Errors found. Exiting."
 

--- a/src/Tintin/Render.hs
+++ b/src/Tintin/Render.hs
@@ -27,7 +27,7 @@ perform docFiles = do
                          |>  map  HtmlFile.fromDocumentationFile
                          |>  mapM HtmlFile.run
                          |$> partitionEithers
-  unless (null errors) (Errors.showAndDie errors)
+  unless (null errors) (Errors.textDie (HtmlFile.showCompilationError <$> errors))
   return htmlFiles
 
 


### PR DESCRIPTION
Thanks again for the great library!  Just some small tweaks that I feel might help with usability with regards to error handling.

*   Error messages are now printed directly instead of "showing"; this means newlines in error messages don't get escaped.
*   Error messages still reported when not in `--verbose`
*   `die` instead of `error`, so users don't see stack traces.

Before:
```
$ tintin
tintin: Errors found. Exiting.                                                                           
CallStack (from HasCallStack):                                                                           
  error, called at src/Universum/Debug.hs:60:11 in universum-1.2.0-3MEu26DcIhX6tbnib8w02P:Universum.Debug
  error, called at src/Tintin/Errors.hs:20:5 in tintin-1.2.5-DoxV48pbgIfLPakZUHgLbo:Tintin.Errors        

$ tintin --verbose
[DEBUG] - Cleaning output directory
[DEBUG] - Reading documentation files at /home/justin/projects/haskell/backprop/doc/
[DEBUG] - Parsing documentation
[DEBUG] - Rendering
[ERROR] - CompilationError "\n/tmp/ghc21681_0/ghc_1.hspp:188:28: error:\n    \8226 Couldn't match type \8216Int\8217 with \8216Double\8217\n      Expected type: Double\n        Actual type: HKD Identity Int\n    \8226 In the expression: i\n      In an equation for \8216getMT2Double\8217: getMT2Double (MT2 _ i _) = i\n    |\n188 | getMT2Double (MT2 _ i _) = i\n
  |                            ^\n"
tintin: Errors found. Exiting.
CallStack (from HasCallStack):
  error, called at src/Universum/Debug.hs:60:11 in universum-1.2.0-3MEu26DcIhX6tbnib8w02P:Universum.Debug
  error, called at src/Tintin/Errors.hs:20:5 in tintin-1.2.5-DoxV48pbgIfLPakZUHgLbo:Tintin.Errors
```

After:

```
$ tintin
Errors found. Exiting.                                               
[ERROR] - CompilationError                                           
                                                                     
/tmp/ghc20043_0/ghc_1.hspp:188:28: error:                            
    • Couldn't match type ‘Int’ with ‘Double’                        
      Expected type: Double                                          
        Actual type: HKD Identity Int                                
    • In the expression: i                                           
      In an equation for ‘getMT2Double’: getMT2Double (MT2 _ i _) = i
    |                                                                
188 | getMT2Double (MT2 _ i _) = i                                   
    |                            ^                                   

$ tintin --verbose
Errors found. Exiting.
[DEBUG] - Cleaning output directory
[DEBUG] - Reading documentation files at /home/justin/projects/haskell/backprop/doc/
[DEBUG] - Parsing documentation
[DEBUG] - Rendering
[ERROR] - CompilationError

/tmp/ghc20649_0/ghc_1.hspp:188:28: error:
    • Couldn't match type ‘Int’ with ‘Double’
      Expected type: Double
        Actual type: HKD Identity Int
    • In the expression: i
      In an equation for ‘getMT2Double’: getMT2Double (MT2 _ i _) = i
    |
188 | getMT2Double (MT2 _ i _) = i
    |                            ^
```