### PR TITLE
Add social metatags (twitter and open graph)

### DIFF
--- a/src/Tintin/Html/Templating.hs
+++ b/src/Tintin/Html/Templating.hs
@@ -136,6 +136,44 @@ tintinHeader :: Project.Info -> Project.Page -> Html ()
 tintinHeader info@Project.Info {..} Project.Page {..} =
   head_ $ do
     title_ ( toHtml $ name <> " - " <> title )
+    -- Twitter Card data
+    meta_ [ name_ "twitter:card"
+          , content_ "summary"
+          ]
+    meta_ [ name_ "twitter:site"
+          , content_ githubLink
+          ]
+    meta_ [ name_ "twitter:title"
+          , content_ (name <> " - " <> title)
+          ]
+    meta_ [ name_ "twitter:description"
+          , content_ synopsis
+          ]
+    meta_ [ name_ "twitter:creator"
+          , content_ githubAuthor
+          ]
+    meta_ [ name_ "twitter:image"
+          , content_ "https://wiki.haskell.org/wikiupload/4/4a/HaskellLogoStyPreview-1.png"
+          ]
+    -- Open Graph data
+    meta_ [ itemprop_ "og:type"
+          , content_ "website"
+          ]
+    meta_ [ itemprop_ "og:site_name"
+          , content_ "theam"
+          ]
+    meta_ [ itemprop_ "og:title"
+          , content_ (name <> " - " <> title)
+          ]
+    meta_ [ itemprop_ "og:url"
+          , content_ (githubLink <> name)
+          ]
+    meta_ [ itemprop_ "og:image"
+          , content_ "https://wiki.haskell.org/wikiupload/4/4a/HaskellLogoStyPreview-1.png"
+          ]
+    meta_ [ itemprop_ "og:description"
+          , content_ synopsis
+          ]
     link_ [ rel_ "stylesheet"
           , href_ "https://fonts.googleapis.com/css?family=IBM+Plex+Sans|Montserrat:500"
           ]

--- a/src/Tintin/Html/Templating.hs
+++ b/src/Tintin/Html/Templating.hs
@@ -141,7 +141,8 @@ tintinHeader info@Project.Info {..} Project.Page {..} =
           , content_ "summary"
           ]
     meta_ [ name_ "twitter:site"
-          , content_ githubLink
+          , content_ ("https://s3-eu-west-1.amazonaws.com/worldwideapps/assets/tintin-" <> (Text.toLower $ show color) <> ".png")
+
           ]
     meta_ [ name_ "twitter:title"
           , content_ (name <> " - " <> title)
@@ -153,7 +154,8 @@ tintinHeader info@Project.Info {..} Project.Page {..} =
           , content_ githubAuthor
           ]
     meta_ [ name_ "twitter:image"
-          , content_ "https://wiki.haskell.org/wikiupload/4/4a/HaskellLogoStyPreview-1.png"
+          , content_ ("https://s3-eu-west-1.amazonaws.com/worldwideapps/assets/tintin-" <> (Text.toLower $ show color) <> ".png")
+
           ]
     -- Open Graph data
     meta_ [ itemprop_ "og:type"
@@ -166,10 +168,11 @@ tintinHeader info@Project.Info {..} Project.Page {..} =
           , content_ (name <> " - " <> title)
           ]
     meta_ [ itemprop_ "og:url"
-          , content_ (githubLink <> name)
+          , content_ githubLink
           ]
     meta_ [ itemprop_ "og:image"
-          , content_ "https://wiki.haskell.org/wikiupload/4/4a/HaskellLogoStyPreview-1.png"
+          , content_  ("https://s3-eu-west-1.amazonaws.com/worldwideapps/assets/tintin-" <> (Text.toLower $ show color) <> ".png")
+
           ]
     meta_ [ itemprop_ "og:description"
           , content_ synopsis


### PR DESCRIPTION
This solves the #5 issue, adding some nice cards when we publish our tintin links through internet! Some screenshots here:
Open graph:
![image](https://user-images.githubusercontent.com/7570085/40623172-6c958a48-629d-11e8-9e4e-ff79d2541086.png)

Twitter card:
![image](https://user-images.githubusercontent.com/7570085/40623206-8ab00422-629d-11e8-8e81-a361ad999b5a.png)

The photo is blue because these docs were made with a blue configuration!