### PR TITLE
Support 'cabal new-build' by adding build-tool-depend

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -57,6 +57,8 @@ library:
   - clay
   - data-has
   - frontmatter
+  verbatim:
+    build-tool-depends: require:requirepp
 
 
 
@@ -72,6 +74,8 @@ executables:
     - tintin
     - universum
     - optparse-generic
+    verbatim:
+      build-tool-depends: require:requirepp
 
 tests:
   tintin-test:


### PR DESCRIPTION
This makes tintin build with ghc 8.4 using cabal new-build