### PR TITLE
Next/prev styling

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                tintin
-version:             1.8.0
+version:             1.9.0
 github:              "theam/tintin"
 license:             Apache-2.0
 author:              "The Agile Monkeys"

--- a/src/Tintin/Html/Style.hs
+++ b/src/Tintin/Html/Style.hs
@@ -29,6 +29,10 @@ style = toText . render $ do
   h2 ? fontSize (em 1.953)
   h3 ? fontSize (em 1.563)
 
+  ".next-prev" ? do
+    marginTop (fromInteger 5 :: Size Percentage)
+    marginBottom (fromInteger 5 :: Size Percentage)
+
   "#header-container" ? do
     marginTop (rem 5)
     marginBottom (rem 5)

--- a/src/Tintin/Html/Style.hs
+++ b/src/Tintin/Html/Style.hs
@@ -30,8 +30,8 @@ style = toText . render $ do
   h3 ? fontSize (em 1.563)
 
   ".next-prev" ? do
-    marginTop (fromInteger 5 :: Size Percentage)
-    marginBottom (fromInteger 5 :: Size Percentage)
+    marginTop (pct 5)
+    marginBottom (pct 5)
 
   "#header-container" ? do
     marginTop (rem 5)

--- a/src/Tintin/Html/Templating.hs
+++ b/src/Tintin/Html/Templating.hs
@@ -65,7 +65,7 @@ wrapPage info context page = toText . renderText $ do
 
 nextPrev :: Project.Context -> Html ()
 nextPrev context = do
-  div_ [class_ "row"] $ do
+  div_ [class_ "row next-prev"] $ do
     whenJust (Project.prevRef context) $ \prev -> do
       div_ [class_ "col-md-4 offset-md-4"] $ do
         a_ [href_ $ Project.refFilename prev] $  do
@@ -74,7 +74,6 @@ nextPrev context = do
       div_ [class_ "col-md-4 ml-auto"] $ do
         a_ [href_ $ Project.refFilename next] $  do
           ( toHtml $ "Next: " <> Project.refTitle next <> " >")
-  br_ []
 
 siteGenerated = do
   div_ [class_ "float-right"] $ do

--- a/src/Tintin/Html/Templating.hs
+++ b/src/Tintin/Html/Templating.hs
@@ -74,6 +74,7 @@ nextPrev context = do
       div_ [class_ "col-md-4 ml-auto"] $ do
         a_ [href_ $ Project.refFilename next] $  do
           ( toHtml $ "Next: " <> Project.refTitle next <> " >")
+  br_ []
 
 siteGenerated = do
   div_ [class_ "float-right"] $ do

--- a/src/Tintin/Html/Templating.hs
+++ b/src/Tintin/Html/Templating.hs
@@ -65,17 +65,15 @@ wrapPage info context page = toText . renderText $ do
 
 nextPrev :: Project.Context -> Html ()
 nextPrev context = do
-  div_ [] $ do
+  div_ [class_ "row"] $ do
     whenJust (Project.prevRef context) $ \prev -> do
-      div_ [] $ do
-        p_ [] $ do
-          a_ [href_ $ Project.refFilename prev] $  do
-            ( toHtml $ "< Previous: " <> Project.refTitle prev )
+      div_ [class_ "col-md-4 offset-md-4"] $ do
+        a_ [href_ $ Project.refFilename prev] $  do
+          ( toHtml $ "< Previous: " <> Project.refTitle prev )
     whenJust (Project.nextRef context) $ \next -> do
-      div_ [] $ do
-        p_ [] $ do
-          a_ [href_ $ Project.refFilename next] $  do
-            ( toHtml $ "Next: " <> Project.refTitle next <> " >")
+      div_ [class_ "col-md-4 ml-auto"] $ do
+        a_ [href_ $ Project.refFilename next] $  do
+          ( toHtml $ "Next: " <> Project.refTitle next <> " >")
 
 siteGenerated = do
   div_ [class_ "float-right"] $ do


### PR DESCRIPTION
Some days ago, @mstksg did a great job adding all functionality of the next/prev buttons for Tintin, so I decided to take the "style" work from that. Here are some screenshots, if anything else is required, just ping me!

- Homepage (one link)

![image](https://user-images.githubusercontent.com/7570085/41151755-99b42e3e-6b09-11e8-8a67-a38aaef85f32.png)

- Other pages (two links)

![image](https://user-images.githubusercontent.com/7570085/41151800-bdcb26ce-6b09-11e8-98fd-7fb999db211d.png)

Maybe the links need more style or different colors, but I would appreciate some advice for that :+1: 