### PR TITLE
Hotfix/project links starting with git://

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                tintin
-version:             1.9.2
+version:             1.9.3
 github:              "theam/tintin"
 license:             Apache-2.0
 author:              "The Agile Monkeys"

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                tintin
-version:             1.9.3
+version:             1.9.5
 github:              "theam/tintin"
 license:             Apache-2.0
 author:              "The Agile Monkeys"

--- a/src/Tintin/Capabilities/Filesystem.hs
+++ b/src/Tintin/Capabilities/Filesystem.hs
@@ -56,8 +56,8 @@ local =
 
   _currentDirectory =
     getCurrentDirectory
-    |$> toText
-    |$> Path
+    & fmap toText
+    & fmap Path
 
   _readFile (Path p) = Core.readFile (toString p)
 

--- a/src/Tintin/ConfigurationLoading.hs
+++ b/src/Tintin/ConfigurationLoading.hs
@@ -103,13 +103,9 @@ loadInfo htmlFiles = do
     in parseGithubUrl unquoted
        & (\t -> if "http" `Text.isPrefixOf` t
                 then Text.splitOn "/" t
-                     & traceShowId
                      & filter (not . Text.isInfixOf "git")
-                     & traceShowId
                      & filter (not . Text.null)
-                     & traceShowId
                      & Unsafe.tail
-                     & traceShowId
                      & Unsafe.head
                 else t
          )
@@ -119,7 +115,6 @@ loadInfo htmlFiles = do
     let unquoted = stripGit $ stripQuotes txt
     in unquoted
        & Text.stripPrefix "github.com/"
-       & traceShowId
        & fromMaybe unquoted
 
   stripQuotes txt =

--- a/src/Tintin/Core.hs
+++ b/src/Tintin/Core.hs
@@ -4,11 +4,8 @@ module Tintin.Core
   , Effectful
   , Pure
 
-  , (|>)
-  , (|$>)
-  , (|>>)
-
   , runEffects
+  , flatMap
   )
 where
 
@@ -35,11 +32,14 @@ type Pure context result =
   Reader context result
 
 
-(|>) :: a -> (a -> b) -> b
-(|>) = (&)
+-- (|>) :: a -> (a -> b) -> b
+-- (|>) = (&)
+--
+-- (|$>) :: Functor f => f a -> (a -> b) -> f b
+-- (|$>) = (<&>)
+--
+-- (|>>) :: Monad m => m a -> (a -> m b) -> m b
+-- (|>>) = (>>=)
 
-(|$>) :: Functor f => f a -> (a -> b) -> f b
-(|$>) = (<&>)
-
-(|>>) :: Monad m => m a -> (a -> m b) -> m b
-(|>>) = (>>=)
+flatMap :: Monad m => (a -> m b) -> m a -> m b
+flatMap = (=<<)

--- a/src/Tintin/Domain/DocumentationFile.hs
+++ b/src/Tintin/Domain/DocumentationFile.hs
@@ -35,6 +35,6 @@ new (Filename filename) rawText =
  where
   parse txt =
     encodeUtf8 @Text @ByteString txt
-    |> FMParser.parseYamlFrontmatter
+    & FMParser.parseYamlFrontmatter
 
 

--- a/src/Tintin/Domain/HtmlFile.hs
+++ b/src/Tintin/Domain/HtmlFile.hs
@@ -29,10 +29,10 @@ fromDocumentationFile :: DocumentationFile
                       -> HtmlFile
 fromDocumentationFile docfile =
   DocumentationFile.content docfile
-   |> ("{-# OPTIONS_GHC -F -pgmF inlitpp #-}\n" <>)
-   |> HtmlFile (DocumentationFile.filename docfile) docTitle
+   & ("{-# OPTIONS_GHC -F -pgmF inlitpp #-}\n" <>)
+   & HtmlFile (DocumentationFile.filename docfile) docTitle
  where
-  docTitle = docfile |> DocumentationFile.frontMatter |> FrontMatter.title
+  docTitle = docfile & DocumentationFile.frontMatter & FrontMatter.title
 
 
 run :: ( Has Filesystem.Capability eff
@@ -46,14 +46,14 @@ run buildTool HtmlFile {..} = do
   let tintinDir = currentDirectory <> "/.stack-work/tintin/"
   let tempDir   = tintinDir <> "temp/"
   let hsFilename = filename
-                   |> Text.breakOn ".md"
-                   |> fst
-                   |> (<> ".hs")
-                   |> (tempDir <>)
+                   & Text.breakOn ".md"
+                   & fst
+                   & (<> ".hs")
+                   & (tempDir <>)
   let htmlFilename = filename
-                     |> Text.breakOn ".md"
-                     |> fst
-                     |> (<> ".html")
+                     & Text.breakOn ".md"
+                     & fst
+                     & (<> ".html")
   Filesystem.deleteIfExists (Filesystem.Path tempDir)
   Filesystem.makeDirectory (Filesystem.Path tempDir)
   Filesystem.writeFile (Filesystem.Path hsFilename) content

--- a/src/Tintin/Errors.hs
+++ b/src/Tintin/Errors.hs
@@ -18,7 +18,7 @@ showAndDie :: ( Has Logging.Capability eff
            -> Effectful eff ()
 showAndDie errors = do
     errors
-     |> mapM_ (Logging.err . show)
+     & mapM_ (Logging.err . show)
     die "Errors found. Exiting."
 
 textDie :: ( Has Logging.Capability eff
@@ -27,6 +27,6 @@ textDie :: ( Has Logging.Capability eff
         -> Effectful eff ()
 textDie errors = do
     errors
-     |> mapM_ Logging.err
+     & mapM_ Logging.err
     die "Errors found. Exiting."
 

--- a/src/Tintin/Html/Templating.hs
+++ b/src/Tintin/Html/Templating.hs
@@ -241,6 +241,6 @@ tintinPostInit = do
 bgColorOf :: Project.Info -> Text
 bgColorOf info =
   Project.color info
-  |> show
-  |> Text.toLower
+  & show
+  & Text.toLower
 

--- a/src/Tintin/Parse.hs
+++ b/src/Tintin/Parse.hs
@@ -22,8 +22,8 @@ docs :: ( Has Logging.Capability eff
 docs docDir filenames = do
   Logging.debug "Parsing documentation"
   (errors, docFiles) <- filenames
-                        |>  mapM (readAndParse docDir)
-                        |$> partitionEithers
+                        & traverse (readAndParse docDir)
+                        & fmap partitionEithers
   unless (null errors) (Errors.showAndDie errors)
   return docFiles
 

--- a/src/Tintin/Render.hs
+++ b/src/Tintin/Render.hs
@@ -26,9 +26,9 @@ perform :: ( Has Logging.Capability eff
 perform buildTool docFiles = do
   Logging.debug "Rendering"
   (errors, htmlFiles) <- docFiles
-                         |>  map  HtmlFile.fromDocumentationFile
-                         |>  mapM (HtmlFile.run buildTool)
-                         |$> partitionEithers
+                         &  map  HtmlFile.fromDocumentationFile
+                         &  mapM (HtmlFile.run buildTool)
+                         & fmap partitionEithers
   unless (null errors) (Errors.textDie (HtmlFile.showCompilationError <$> errors))
   return htmlFiles
 
@@ -82,8 +82,8 @@ withContext ps = elems contextMap
     -- alphabetical sorting.
     contextMap :: Map Text (Project.Page, Project.Context)
     contextMap = ps
-             |$> (\p -> (Project.filename p, (p, makeContext p)))
-             |>  Map.fromList
+             & fmap (\p -> (Project.filename p, (p, makeContext p)))
+             & Map.fromList
     -- | Actual function that pairs up each page with its context (next and
     -- previous links).
     --
@@ -96,16 +96,16 @@ withContext ps = elems contextMap
     makeContext :: Project.Page -> Project.Context
     makeContext p
         | fn == "index.html" = Map.lookupMin pageMap
-                                 |$> snd
-                                 |$> makeRef
-                                 |> Project.Context Nothing
+                                 & fmap snd
+                                 & fmap makeRef
+                                 & Project.Context Nothing
         | otherwise          =
             let prev = Map.lookupLT fn pageMap
-                        |$> snd
-                        |$> makeRef
+                        & fmap snd
+                        & fmap makeRef
                 next = Map.lookupGT fn pageMap
-                        |$> snd
-                        |$> makeRef
+                        & fmap snd
+                        & fmap makeRef
             in  Project.Context (prev <|> indexRef) next  -- if no prev, use index
       where
         fn = Project.filename p


### PR DESCRIPTION
@lancelet reported #37 , meaning that links that looked like `git://...` werent properly rendered, this PR should fix it.

@lancelet , I've tested it with a couple of cabal files, could you clone this branch and see if it works for you?

Thanks in advance! 😄 