### PR TITLE
Suggest `cabal new-*` commands

### DIFF
--- a/doc/01-getting-started.md
+++ b/doc/01-getting-started.md
@@ -29,9 +29,8 @@ before you run it.
 If you prefer `cabal` over Stack, you can run:
 
 ```bash
-cabal update
-cabal install inliterate
-cabal install tintin
+cabal new-update
+cabal new-install tintin
 ```
 
 ## Creating a new project with the Tintin template


### PR DESCRIPTION
Cabal nix-style local builds (present since cabal-install 1.24) avoid cabal-hell and should be preferred over plain `cabal install`. Also dependency on `inliterate` is picked up automatically.

For reference: https://www.haskell.org/cabal/release/cabal-latest/doc/users-guide/nix-local-build-overview.html