### PR TITLE
Add blockquote style

### DIFF
--- a/src/Tintin/Html/Style.hs
+++ b/src/Tintin/Html/Style.hs
@@ -29,6 +29,11 @@ style = toText . render $ do
   h2 ? fontSize (em 1.953)
   h3 ? fontSize (em 1.563)
 
+  blockquote ? do
+    borderLeft solid (px 4) "#DDD"
+    paddingLeft (rem 1)
+    color "#777"
+
   ".next-prev" ? do
     marginTop (pct 5)
     marginBottom (pct 5)


### PR DESCRIPTION
It's a simple one, similar to github's markdown blocks.

> Like this.
> Some tweaks may require to make `inline code` more `readable`, though.

I used a few of them to make some "heads up" paragraphs and came out exactly the same.