### PR TITLE
Added support for custom background color

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -51,6 +51,7 @@ library:
   - directory
   - temporary
   - process
+  - inflections
   - inliterate
   - universum
   - lucid

--- a/src/Tintin/ConfigurationLoading.hs
+++ b/src/Tintin/ConfigurationLoading.hs
@@ -15,6 +15,7 @@ require Data.Text
 import Tintin.Core
 import qualified Universum.Unsafe as Unsafe
 import Text.Read (read)
+import qualified Text.Inflections as Inflections
 
 
 data ConfigurationLoading
@@ -81,15 +82,12 @@ loadInfo htmlFiles = do
 
   makeColor :: Text -> Project.Color
   makeColor txt =
-    let capitalLetter = txt
-                        & Text.head
-                        & Text.singleton
-                        & Text.toUpper
-        restOfText    = txt
-                        & Text.tail
-    in  (capitalLetter <> restOfText)
-         & toString
-         & read
+    case Text.stripPrefix "#" txt of
+      Just _ -> Project.HexColor txt
+      Nothing -> Inflections.SomeWord <$> Inflections.mkWord txt
+        & Inflections.titleize 
+        & toString
+        & read
 
   getFieldValue field txt = txt
                           & lines

--- a/src/Tintin/Domain/Project.hs
+++ b/src/Tintin/Domain/Project.hs
@@ -16,6 +16,7 @@ data Color
   | LightOrange
   | Red
   | Grey
+  | HexColor Text
   deriving (Show, Read)
 
 

--- a/src/Tintin/Html/Style.hs
+++ b/src/Tintin/Html/Style.hs
@@ -5,10 +5,12 @@ import Tintin.Core as Core hiding (( & ), rem, (|>))
 import Clay
 import qualified Clay.Media as Media
 
+require Tintin.Domain.Project
+
 data Style
 
-style :: Text
-style = toText . render $ do
+style :: Project.Color -> Text
+style projectColor = toText . render $ do
   html ? do
     height (pct 100)
     minHeight (pct 100)
@@ -218,11 +220,11 @@ style = toText . render $ do
   ".tintin-bg-70" ? do
     backgroundColor (rgba 255 255 255 0.15)
 
-  forM colorNames $ \(colorName, colorValue) ->
+  forM (colorNames projectColor) $ \(colorName, colorValue) ->
     (element $ ".tintin-bg-" <> colorName) ? do
       backgroundColor colorValue
 
-  forM colorNames $ \(colorName, colorValue) ->
+  forM (colorNames projectColor) $ \(colorName, colorValue) ->
     (element $ ".tintin-fg-" <> colorName) ? do
       color colorValue
 
@@ -265,9 +267,15 @@ style = toText . render $ do
       position relative
 
 
-
-colorNames :: [(Text, Color)]
-colorNames =
+-- TODO: This list is used to generate all possible CSS classes for supported colors. 
+-- As we now know at compile time what's he right color, we could remove this list and
+-- generate the required colors only.
+colorNames :: Project.Color -> [(Text, Color)]
+colorNames (Project.HexColor customColor) =
+  [ ("custom"     , clayColor)
+  ]
+  where clayColor = fromString $ toString customColor
+colorNames _ =
   [ ("black"      , "#1d1f21")
   , ("white"      , "#f5f8f6")
   , ("grey"       , "#4D4D4D")

--- a/src/Tintin/Html/Templating.hs
+++ b/src/Tintin/Html/Templating.hs
@@ -30,10 +30,10 @@ wrapPage info context page = toText . renderText $ do
       div_ [id_ "main-container", class_ "h-100"] $ do
         section_ [ id_ "content"] $ do
           div_ [id_ "wrapper", class_ "toggled"] $ do
-            div_ [id_ "sidebar-wrapper", class_ $ "h-100 tintin-bg-" <> bgColorOf info] $ do
+            div_ [id_ "sidebar-wrapper", class_ $ "h-100 tintin-bg-" <> bgColorNameOf info] $ do
               div_ [ class_ "h-100 tintin-bg-70"] ( p_ "" )
               ul_ [ class_ "sidebar-nav"] $ do
-                li_ [ class_ $ "sidebar-brand d-flex tintin-bg-" <> bgColorOf info] $ do
+                li_ [ class_ $ "sidebar-brand d-flex tintin-bg-" <> bgColorNameOf info] $ do
                   a_ [href_ "index.html", class_ "align-self-center tintin-fg-white"] $ do
                     case Project.logoUrl info of
                       Nothing -> toHtml $ Project.name info
@@ -92,7 +92,7 @@ wrapHome info nextRef page = toText . renderText $ do
     tintinHeader info page
     body_ [class_ "tintin-fg-black tintin-bg-white"] $ do
 
-      div_ [class_ $ "tintin-navigation tintin-bg-" <> bgColorOf info] $ do
+      div_ [class_ $ "tintin-navigation tintin-bg-" <> bgColorNameOf info] $ do
         div_ [class_ "cover-container d-flex p-3 mx-auto flex-column tintin-fg-white"] $ do
           main_ [role_ "main", class_ "masthead mb-auto"] $ do
             div_ [class_ "container"] $ do
@@ -144,7 +144,7 @@ wrapHome info nextRef page = toText . renderText $ do
               when (isJust $ Project.githubLink info) $ do
               "Developed by "
               a_ [ href_ $ "https://github.com/" <> (fromJust $ Project.githubAuthor info)
-                 , class_ $ "tintin-fg-" <> bgColorOf info
+                 , class_ $ "tintin-fg-" <> bgColorNameOf info
                  ] (toHtml $ fromJust $ Project.githubAuthor info)
           div_ [class_ "col", style_ ""] $ do
             siteGenerated
@@ -213,14 +213,14 @@ tintinHeader info@Project.Info {..} Project.Page {..} =
           ]
     link_ [ rel_ "shortcut icon"
           , href_ ( asset $ "favicon-"
-                  <> bgColorOf info
+                  <> bgColorNameOf info
                   <> ".ico"
                   )
           ]
     link_ [ rel_ "stylesheet"
           , href_ "https://cdn.jsdelivr.net/npm/katex@0.10.0-alpha/dist/katex.min.css"
           ]
-    style_ Style.style
+    style_ $ Style.style $ Project.color info
 
 
 tintinPostInit :: Html ()
@@ -236,9 +236,12 @@ tintinPostInit = do
   script_ [src_ "https://cdn.jsdelivr.net/npm/katex@0.10.0-alpha/dist/katex.min.js"] ("" :: Text)
   script_ [src_ "https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0/contrib/auto-render.min.js"] ("" :: Text)
   script_ "renderMathInElement(document.body);"
-bgColorOf :: Project.Info -> Text
-bgColorOf info =
-  Project.color info
-  & show
-  & Text.toLower
 
+bgColorNameOf :: Project.Info -> Text
+bgColorNameOf info =
+  case color of
+    Project.HexColor color -> fromString "custom"
+    _ -> color
+          & show
+          & Text.toLower
+  where color = Project.color info


### PR DESCRIPTION
This is a rudimentary implementation that works, but there’s definitely a lot of room for cleanup and improvement. 

If you set a hexadecimal color value in tintin’s config file instead of one of the default fixed options, the parser stores it differently and creates custom CSS to properly show it.