### PR TITLE
Allow overriding the project configuration in tintin's config file

### DIFF
--- a/doc/03-customizing-your-site.md
+++ b/doc/03-customizing-your-site.md
@@ -12,14 +12,19 @@ color: blue
 ```
 
 This is the main tintin configuration file. By default, Tintin will try to pull the basic
-information directly from your `package.yaml` or `*.cabal` configuration file, but you can override
-the settings in your `.tintin.yml` file too:
+information directly from your `package.yaml` or `*.cabal` configuration file if they're present, 
+but you can override the settings in your `.tintin.yml` file too:
 
 ```yaml
-color: blue
+name: Wonderful project
+synopsis: This is a project that do wonderful things
+github: theam/wonderful-project
+author: Wonder Woman
+color: #AB2D1C
+logo: https://upload.wikimedia.org/wikipedia/en/3/3a/Wonder_Woman_Vol_5_16.png
 ```
 
-## Changing the color
+## Changing the color theme
 
 The `color` setting is used by tintin to generate the theme for your website.
 You can either set one of the preset color themes or set a RGB hexadecimal code:
@@ -72,7 +77,7 @@ color: blue
 
 ### Use a custom hexadecimal color code
 
-Just write your color code as if you were writting it in a CSS file:
+Just write your hexadecimal color code as if you were writting it in a CSS file:
 
 ```yaml
 color: #424242
@@ -80,16 +85,13 @@ color: #424242
 
 This color will be set as the main background color and a shade of it will be generated for the menus backgrounds. Take into account that title text will remain white and content will be black text on white background, so dark or saturated colors will work better.
 
-## Changing the project title for a logo
+## Setting a custom logo
 
-Tintin also gives you the possibility of using your own logo.
-
-To do so use the `logo` setting:
+By default, tintin will show the project name in the frontpage, but it can be replaced by an image setting an absolute URL in the `logo` option:
 
 ```yaml
 color: blue
 logo: https://github.com/theam/tintin/raw/master/assets/logo.svg
 ```
 
-It is recommended that the logo has transparent background.
-
+For the best results, we recommend to use an image with transparent background.

--- a/doc/03-customizing-your-site.md
+++ b/doc/03-customizing-your-site.md
@@ -17,7 +17,7 @@ but you can override the settings in your `.tintin.yml` file too:
 
 ```yaml
 name: Wonderful project
-synopsis: This is a project that do wonderful things
+synopsis: This is a project that does wonderful things
 github: theam/wonderful-project
 author: Wonder Woman
 color: #AB2D1C
@@ -77,7 +77,7 @@ color: blue
 
 ### Use a custom hexadecimal color code
 
-Just write your hexadecimal color code as if you were writting it in a CSS file:
+Just write your hexadecimal color code as if you were writing it in a CSS file:
 
 ```yaml
 color: #424242

--- a/src/Tintin/ConfigurationLoading.hs
+++ b/src/Tintin/ConfigurationLoading.hs
@@ -106,19 +106,16 @@ loadTintinConfig pages ctx = do
     in unquoted
        & Text.stripPrefix "github.com/"
        & fromMaybe unquoted
-
   stripGit txt =
     txt
       & Text.stripPrefix "git://"
       & flatMap (Text.stripSuffix ".git")
       & fromMaybe txt
-
   stripQuotes txt =
     txt
     & Text.stripPrefix "\""
     & flatMap (Text.stripSuffix "\"")
     & fromMaybe txt
-
   errorMessages = unlines
     ["Tintin usually generates a .tintin.yml file with a color configuration. Maybe you don't have enough permissions?"
     , ""
@@ -140,9 +137,9 @@ loadInfo :: ( Has Logging.Capability eff
             )
          => [HtmlFile]
          -> Effectful eff Project.Info
-loadInfo htmlFiles = do
-  let pages = htmlFiles
-              & map (\HtmlFile.HtmlFile {..} -> Project.Page title content filename)
+loadInfo htmlFiles =
   Filesystem.currentDirectory
     >>= loadProjectConfig
     >>= loadTintinConfig pages
+ where
+  pages = htmlFiles & map (\HtmlFile.HtmlFile {..} -> Project.Page title content filename)

--- a/src/Tintin/ConfigurationLoading.hs
+++ b/src/Tintin/ConfigurationLoading.hs
@@ -17,21 +17,123 @@ import qualified Universum.Unsafe as Unsafe
 import Text.Read (read)
 import qualified Text.Inflections as Inflections
 
-
 data ConfigurationLoading
 
-readFileIfExists :: ( Has Logging.Capability eff
+data ProjectContext = ProjectContext
+  { name            :: Maybe Text
+  , synopsis        :: Maybe Text
+  , github          :: Maybe Text
+  , location        :: Maybe Text
+  , author          :: Maybe Text
+  , projectLocation :: Filesystem.Path
+  }
+
+getFieldValue :: Text -> Text -> Maybe Text
+getFieldValue field txt = txt
+                        & lines
+                        & filter (\t -> field `Text.isPrefixOf` Text.strip t)
+                        & safeHead
+                        & fmap Text.strip
+                        & flatMap (Text.stripPrefix $ field <> ":")
+                        & fmap Text.strip
+
+loadProjectConfig :: ( Has Logging.Capability eff
+                     , Has Filesystem.Capability eff
+                     )
+                   => Filesystem.Path -> Effectful eff ProjectContext
+loadProjectConfig currentPath = do
+  files <- Filesystem.list currentPath
+  let packageYamlFile = find isPackageYaml files
+  let cabalFile       = find isCabalFile files
+  case packageYamlFile <|> cabalFile of
+    Just file -> do
+      Logging.debug "Reading project info"
+      projectConfigFile <- Filesystem.readFile file
+      return ProjectContext
+        { name            = projectConfigFile & getFieldValue "name"
+        , synopsis        = projectConfigFile & getFieldValue "synopsis"
+        , github          = projectConfigFile & getFieldValue "github"
+        , location        = projectConfigFile & getFieldValue "location"
+        , author          = projectConfigFile & getFieldValue "author"
+        , projectLocation = currentPath
+        }
+    Nothing -> return ProjectContext
+      { name            = Nothing
+      , synopsis        = Nothing
+      , github          = Nothing
+      , location        = Nothing
+      , author          = Nothing
+      , projectLocation = currentPath
+      }
+ where
+  isPackageYaml (Filesystem.Path p) = p == "package.yaml"
+  isCabalFile   (Filesystem.Path p) = ".cabal" `Text.isInfixOf` p
+
+loadTintinConfig :: ( Has Logging.Capability eff
                     , Has Filesystem.Capability eff
                     )
-                 => Text -> Text -> Effectful eff (Maybe Text)
-readFileIfExists currentDir filename = do
-  let path = Filesystem.Path $ currentDir <> "/" <> filename
-  Logging.debug $ "Reading " <> filename
-  fileExists <- Filesystem.doesExist path
-  if fileExists then do
-    text <- Filesystem.readFile path
-    return (Just text)
-  else return Nothing
+                 => [Project.Page]
+                 -> ProjectContext
+                 -> Effectful eff Project.Info
+loadTintinConfig pages ctx = do
+  let Filesystem.Path currentPath = projectLocation ctx
+      tintinPath = Filesystem.Path $ currentPath <> "/.tintin.yml"
+  tintinExists <- Filesystem.doesExist tintinPath
+  unless tintinExists $ Filesystem.writeFile tintinPath "color: blue\n"
+  tintinConfig <- Filesystem.readFile tintinPath
+  let
+    projectName     = (tintinConfig & getFieldValue "name") <|> (name ctx)
+    projectSynopsis = (tintinConfig & getFieldValue "synopsis") <|> (synopsis ctx)
+    projectGithub   = (tintinConfig & getFieldValue "github") <|> (github ctx) <|> (location ctx)
+    projectAuthor   = (tintinConfig & getFieldValue "author") <|> (author ctx)
+    tintinColor     = tintinConfig & getFieldValue "color"
+    tintinLogo      = tintinConfig & getFieldValue "logo"
+  when (isNothing projectName) (Errors.showAndDie ["Project must have a name. Please set it in package.yaml or *.cabal."])
+  when (isNothing projectSynopsis) (Errors.showAndDie ["Project must have a synopsis. Please set it in package.yaml or *.cabal."])
+  when (isNothing tintinColor) (Errors.showAndDie [errorMessages])
+  return Project.Info
+    { name = Unsafe.fromJust projectName
+    , synopsis = Unsafe.fromJust projectSynopsis
+    , githubLink = parseGithubUrl <$> projectGithub
+    , githubAuthor = projectAuthor
+    , color = makeColor $ Unsafe.fromJust tintinColor
+    , logoUrl = tintinLogo
+    , pages = pages
+    }
+ where
+  parseGithubUrl txt =
+    let unquoted = stripGit $ stripQuotes txt
+    in unquoted
+       & Text.stripPrefix "github.com/"
+       & fromMaybe unquoted
+
+  stripGit txt =
+    txt
+      & Text.stripPrefix "git://"
+      & flatMap (Text.stripSuffix ".git")
+      & fromMaybe txt
+
+  stripQuotes txt =
+    txt
+    & Text.stripPrefix "\""
+    & flatMap (Text.stripSuffix "\"")
+    & fromMaybe txt
+
+  errorMessages = unlines
+    ["Tintin usually generates a .tintin.yml file with a color configuration. Maybe you don't have enough permissions?"
+    , ""
+    , ""
+    , "Try creating .tintin.yml and adding color:blue to it."
+    ]
+
+makeColor :: Text -> Project.Color
+makeColor txt =
+  case Text.stripPrefix "#" txt of
+    Just _ -> Project.HexColor txt
+    Nothing -> Inflections.SomeWord <$> Inflections.mkWord txt
+      & Inflections.titleize
+      & toString
+      & read
 
 loadInfo :: ( Has Logging.Capability eff
             , Has Filesystem.Capability eff
@@ -41,103 +143,6 @@ loadInfo :: ( Has Logging.Capability eff
 loadInfo htmlFiles = do
   let pages = htmlFiles
               & map (\HtmlFile.HtmlFile {..} -> Project.Page title content filename)
-  Filesystem.Path currentDir <- Filesystem.currentDirectory
-  files <- Filesystem.list (Filesystem.Path currentDir)
-  let packageYamlFile = find isPackageYaml files
-  let cabalFile       = find isCabalFile files
-  case packageYamlFile <|> cabalFile of
-    Nothing -> do
-      Errors.showAndDie ["No package.yaml or *.cabal file found."]
-      error ""
-
-    Just p -> do
-      let tintinPath = Filesystem.Path $ currentDir <> "/.tintin.yml"
-      Logging.debug "Reading project info"
-      projectInfoFile <- Filesystem.readFile p
-      tintinExists    <- Filesystem.doesExist tintinPath
-      unless tintinExists $
-        Filesystem.writeFile tintinPath "color: blue\n"
-      tintinFile <- Filesystem.readFile tintinPath
-      let
-        projectName     = projectInfoFile & getFieldValue "name"
-        projectSynopsis = projectInfoFile & getFieldValue "synopsis"
-        projectGithub   = (projectInfoFile & getFieldValue "github")
-                          <|> (projectInfoFile & getFieldValue "location")
-        projectAuthor   = projectGithub & fmap getAuthor
-        tintinColor     = tintinFile & getFieldValue "color"
-        tintinLogo      = tintinFile & getFieldValue "logo"
-      when (isNothing projectName) (Errors.showAndDie ["Project must have a name. Please set it in package.yaml or *.cabal."])
-      when (isNothing projectSynopsis) (Errors.showAndDie ["Project must have a synopsis. Please set it in package.yaml or *.cabal."])
-      when (isNothing tintinColor)
-        (Errors.showAndDie [errorMessages])
-      return Project.Info
-        { name = Unsafe.fromJust projectName
-        , synopsis = Unsafe.fromJust projectSynopsis
-        , githubLink = parseGithubUrl <$> projectGithub
-        , githubAuthor = projectAuthor
-        , color = makeColor $ Unsafe.fromJust tintinColor
-        , logoUrl = tintinLogo
-        , pages = pages
-        }
-
- where
-  errorMessages = unlines
-    ["Tintin usually generates a .tintin.yml file with a color configuration. Maybe you don't have enough permissions?"
-    , ""
-    , ""
-    , "Try creating .tintin.yml and adding color:blue to it."
-    ]
-  isPackageYaml (Filesystem.Path p) =
-    p == "package.yaml"
-
-  isCabalFile   (Filesystem.Path p) =
-    ".cabal" `Text.isInfixOf` p
-
-  makeColor :: Text -> Project.Color
-  makeColor txt =
-    case Text.stripPrefix "#" txt of
-      Just _ -> Project.HexColor txt
-      Nothing -> Inflections.SomeWord <$> Inflections.mkWord txt
-        & Inflections.titleize
-        & toString
-        & read
-
-  getFieldValue field txt = txt
-                          & lines
-                          & filter (\t -> field `Text.isPrefixOf` Text.strip t)
-                          & safeHead
-                          & fmap Text.strip
-                          & flatMap (Text.stripPrefix $ field <> ":")
-                          & fmap Text.strip
-  getAuthor txt =
-    let unquoted = stripQuotes txt
-    in parseGithubUrl unquoted
-       & (\t -> if "http" `Text.isPrefixOf` t
-                then Text.splitOn "/" t
-                     & filter (not . Text.isInfixOf "git")
-                     & filter (not . Text.null)
-                     & Unsafe.tail
-                     & Unsafe.head
-                else t
-         )
-       & Text.takeWhile (/= '/')
-
-  parseGithubUrl txt =
-    let unquoted = stripGit $ stripQuotes txt
-    in unquoted
-       & Text.stripPrefix "github.com/"
-       & fromMaybe unquoted
-
-  stripQuotes txt =
-    txt
-    & Text.stripPrefix "\""
-    & flatMap (Text.stripSuffix "\"")
-    & fromMaybe txt
-
-  stripGit txt =
-    txt
-    & Text.stripPrefix "git://"
-    & flatMap (Text.stripSuffix ".git")
-    & fromMaybe txt
-
-
+  Filesystem.currentDirectory
+    >>= loadProjectConfig
+    >>= loadTintinConfig pages

--- a/src/Tintin/ConfigurationLoading.hs
+++ b/src/Tintin/ConfigurationLoading.hs
@@ -20,6 +20,19 @@ import qualified Text.Inflections as Inflections
 
 data ConfigurationLoading
 
+readFileIfExists :: ( Has Logging.Capability eff
+                    , Has Filesystem.Capability eff
+                    )
+                 => Text -> Text -> Effectful eff (Maybe Text)
+readFileIfExists currentDir filename = do
+  let path = Filesystem.Path $ currentDir <> "/" <> filename
+  Logging.debug $ "Reading " <> filename
+  fileExists <- Filesystem.doesExist path
+  if fileExists then do
+    text <- Filesystem.readFile path
+    return (Just text)
+  else return Nothing
+
 loadInfo :: ( Has Logging.Capability eff
             , Has Filesystem.Capability eff
             )
@@ -85,7 +98,7 @@ loadInfo htmlFiles = do
     case Text.stripPrefix "#" txt of
       Just _ -> Project.HexColor txt
       Nothing -> Inflections.SomeWord <$> Inflections.mkWord txt
-        & Inflections.titleize 
+        & Inflections.titleize
         & toString
         & read
 


### PR DESCRIPTION
With this change, Tintin can now be run out of the main Haskell project root folder because the existence of `package.yaml` and `*.cabal` is now optional (as soon as all required config variables are present in `.tintin.yml`). 

This is useful to be able to use Tintin in multi-package projects, addressing Issue #51 

#### TODO:
- [x] Implement the main functionality
- [x] Rebase to master to get last version of documentation
- [x] Document the new features and supported configuration options